### PR TITLE
feat(authentication): reuse authentication cookie and close account on wrong credentials

### DIFF
--- a/internal/controller/notification.go
+++ b/internal/controller/notification.go
@@ -78,14 +78,14 @@ func (c *etnaNotificationController) SendPushNotification() error {
 		wg.Add(1)
 		go func() {
 			// Standard notifications
-			err := usecase.SendPushNotificationForUser(user, c.NotificationRepository, c.EtnaWebService, c.DiscordService)
+			err := usecase.SendPushNotificationForUser(user, c.NotificationRepository, c.UserRepository, c.EtnaWebService, c.DiscordService)
 			if err != nil {
 				usecase.SendErrorNotification(c.DiscordService, fmt.Sprintf("[ERROR] Something happens during cron push notification: %s", err.Error()))
 				log.Printf("[ERROR] Something happens during cron push notification: %+v", err)
 			}
 
 			// Calendar notifications
-			err = usecase.SendCalendarPushNotificationForUser(user, c.CalendarRepository, c.EtnaWebService, c.DiscordService)
+			err = usecase.SendCalendarPushNotificationForUser(user, c.CalendarRepository, c.UserRepository, c.EtnaWebService, c.DiscordService)
 			if err != nil {
 				usecase.SendErrorNotification(c.DiscordService, fmt.Sprintf("[ERROR] Something happens during cron push calendar notification: %s", err.Error()))
 				log.Printf("[ERROR] Something happens during cron push calendar notification: %+v", err)

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"gorm.io/gorm"
+	"net/http"
 )
 
 const (
@@ -17,4 +18,21 @@ type User struct {
 	Login          string `json:"login"`
 	Password       string `json:"password"`
 	Status         string `json:"status"`
+	authentication *http.Cookie
+}
+
+func (u *User) SetAuthentication(cookie *http.Cookie) {
+	u.authentication = cookie
+}
+
+func (u *User) HasValidAuthentication() bool {
+	if u.authentication == nil {
+		return false
+	}
+
+	return u.authentication.Valid() == nil
+}
+
+func (u *User) GetAuthentication() *http.Cookie {
+	return u.authentication
 }

--- a/internal/service/etna.go
+++ b/internal/service/etna.go
@@ -24,6 +24,8 @@ type etnaWebService struct {
 	C *req.Client
 }
 
+type ErrorWrongCredentials error
+
 type IEtnaWebService interface {
 	LoginCookie(login, password string) (*http.Cookie, error)
 	RetrieveUnreadNotifications(authenticationCookie *http.Cookie, username string) (notifications []*domain.EtnaNotification, err error)
@@ -53,7 +55,7 @@ func (s *etnaWebService) LoginCookie(login, password string) (*http.Cookie, erro
 		return nil, err
 	}
 	if response.StatusCode == http.StatusUnauthorized {
-		return nil, fmt.Errorf("[ERROR] Wrong credentials for user : %s", login)
+		return nil, ErrorWrongCredentials(fmt.Errorf("[ERROR] Wrong credentials for user : %s", login))
 	}
 	if len(response.Cookies()) == 0 {
 		return nil, fmt.Errorf("[ERROR] Connection failed, no cookie in response body, user : %s", login)

--- a/internal/usecase/notification.go
+++ b/internal/usecase/notification.go
@@ -10,14 +10,18 @@ import (
 )
 
 // RetrieveUnreadNotificationForUser returns all unread notifications for the current user
-func RetrieveUnreadNotificationForUser(user *domain.User, webService service.IEtnaWebService) ([]*domain.EtnaNotification, error) {
+func RetrieveUnreadNotificationForUser(
+	user *domain.User,
+	webService service.IEtnaWebService,
+	userRepository repository.IUserRepository,
+	discordService service.IDiscordService) ([]*domain.EtnaNotification, error) {
 	// Perform etna web service authentication to get authenticator cookie
-	authenticationCookie, err := webService.LoginCookie(user.Login, user.Password)
+	err := AuthenticateUser(user, webService, userRepository, discordService)
 	if err != nil {
 		return nil, err
 	}
 	// Retrieve unread notifications
-	notifications, err := webService.RetrieveUnreadNotifications(authenticationCookie, user.Login)
+	notifications, err := webService.RetrieveUnreadNotifications(user.GetAuthentication(), user.Login)
 	if err != nil {
 		return nil, err
 	}
@@ -31,9 +35,10 @@ func RetrieveUnreadNotificationForUser(user *domain.User, webService service.IEt
 func SendPushNotificationForUser(
 	user *domain.User,
 	notificationRepository repository.INotificationRepository,
+	userRepository repository.IUserRepository,
 	etnaWebService service.IEtnaWebService,
 	discordService service.IDiscordService) error {
-	notifications, err := RetrieveUnreadNotificationForUser(user, etnaWebService)
+	notifications, err := RetrieveUnreadNotificationForUser(user, etnaWebService, userRepository, discordService)
 	if err != nil {
 		return err
 	}

--- a/internal/usecase/register.go
+++ b/internal/usecase/register.go
@@ -31,7 +31,7 @@ func CreateServerInvitation(discordService service.IDiscordService, channelID st
 func CheckEtnaAccountValidity(etnaWebService service.IEtnaWebService, login, password string) error {
 	// Check if the etna account if valid by making authentication
 	if _, err := etnaWebService.LoginCookie(login, password); err != nil {
-		log.Printf("[DEBUG]: user have bad credentials are register : %s", login)
+		log.Printf("[ERROR]: user have bad credentials are register : %s", login)
 		return fmt.Errorf("failed to authenticate on etna web service : %w", err)
 	}
 
@@ -161,10 +161,9 @@ func StopNotifications(userRepository repository.IUserRepository, discordService
 		return nil
 	}
 
-	user.Status = domain.StatusClose
-	_, err = userRepository.UpdateStatus(user)
+	err = UserStopAccount(user, userRepository, discordService)
 	if err != nil {
-		discordService.ReplyInteractiveCommand("error occurred during stop", i)
+		discordService.ReplyInteractiveCommand("error occurred during stop notifications", i)
 		log.Printf("[ERROR] error occurred during stop user %s : %+v", discordName, err)
 		return fmt.Errorf("[ERROR] error occurred during stop user %s : %w", discordName, err)
 	}

--- a/internal/usecase/user.go
+++ b/internal/usecase/user.go
@@ -1,0 +1,48 @@
+package usecase
+
+import (
+	"errors"
+	"log"
+
+	"etna-notification/internal/domain"
+	"etna-notification/internal/repository"
+	"etna-notification/internal/service"
+)
+
+// AuthenticateUser or close account if bad credentials. Reuse authentication is user already authenticated.
+func AuthenticateUser(
+	user *domain.User,
+	webService service.IEtnaWebService,
+	userRepository repository.IUserRepository,
+	discordService service.IDiscordService) error {
+	// If the user has a valid authentication cookie, there is no need to log in again.
+	if user.HasValidAuthentication() {
+		log.Printf("[DEBUG] user %s already authenticated, no need to login again", user.Login)
+		return nil
+	}
+
+	// Perform etna web service authentication to get authenticator cookie
+	authenticationCookie, err := webService.LoginCookie(user.Login, user.Password)
+	if err != nil {
+		var wrongCredError *service.ErrorWrongCredentials
+		if errors.As(err, wrongCredError) {
+			return UserStopAccount(user, userRepository, discordService)
+		}
+	}
+
+	user.SetAuthentication(authenticationCookie)
+
+	return err
+}
+
+// UserStopAccount defined the user account stats to close and send a message to personal channel to inform.
+func UserStopAccount(user *domain.User, userRepository repository.IUserRepository, discordService service.IDiscordService) error {
+	user.Status = domain.StatusClose
+	_, err := userRepository.UpdateStatus(user)
+	if err != nil {
+		return err
+	}
+
+	_, err = discordService.SendTextMessage(user.ChannelID, "Your account has been closed. You will not receive notifications anymore.")
+	return err
+}


### PR DESCRIPTION
Add authentication embed property in user model

Reuse this authentication if user already logged in during notification process.

Add a user usecase to close account and send a message in the channel to inform the user.

When the etna api returns 401, this means credentials are wrong, so we close the account.